### PR TITLE
fix: poetry pyproject not found & deprecated actions/cache

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,7 +22,7 @@ runs:
       run: python -m pip install poetry==1.8.4
 
     - name: Cache the virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ./.venv
         key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}

--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: python -m poetry install
+      working-directory: ${{ github.action_path }}
 
     - name: Pass Inputs to Shell
       run: |
@@ -40,3 +41,4 @@ runs:
       id: map-workflow-output
       run: python -m poetry run ci
       shell: bash
+      working-directory: ${{ github.action_path }}


### PR DESCRIPTION
- [x] Tested the workflow locally with [act](https://github.com/nektos/act)

Fixes error:
 ```
Poetry could not find a pyproject.toml file in /home/runner/work/maps/maps or its parents
```

Fixes deprecation warnings:
 - [notice-of-upcoming-deprecations-and-changes-in-github-actions-services](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/)
 - [github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)
 - [github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)